### PR TITLE
feat: Add frame pacing.

### DIFF
--- a/SmashSoda/DX11.cpp
+++ b/SmashSoda/DX11.cpp
@@ -86,6 +86,7 @@ void DX11::clear()
 	SAFE_RELEASE(_deskDupl);
 	SAFE_RELEASE(_lAcquiredDesktopImage);
 	releaseScaledRenderTarget();
+	releaseLastSubmittedTexture();
 }
 
 void DX11::releaseScaledRenderTarget()
@@ -100,6 +101,41 @@ void DX11::releaseScaledRenderTarget()
 	SAFE_RELEASE(_vertexBuffer);
 	SAFE_RELEASE(_lanczosParamsCB);
 	_scalingInitialized = false;
+}
+
+void DX11::releaseLastSubmittedTexture()
+{
+	SAFE_RELEASE(_lastSubmittedTexture);
+	_lastSubmittedWidth = 0;
+	_lastSubmittedHeight = 0;
+	_lastSubmittedFormat = DXGI_FORMAT_UNKNOWN;
+}
+
+bool DX11::ensureLastSubmittedTexture(UINT width, UINT height, DXGI_FORMAT format)
+{
+	if (format == DXGI_FORMAT_UNKNOWN) return false;
+	if (_lastSubmittedTexture && _lastSubmittedWidth == width && _lastSubmittedHeight == height && _lastSubmittedFormat == format)
+		return true;
+	releaseLastSubmittedTexture();
+	if (!_device) return false;
+	D3D11_TEXTURE2D_DESC texDesc = {};
+	texDesc.Width = width;
+	texDesc.Height = height;
+	texDesc.MipLevels = 1;
+	texDesc.ArraySize = 1;
+	texDesc.Format = format;
+	texDesc.SampleDesc.Count = 1;
+	texDesc.SampleDesc.Quality = 0;
+	texDesc.Usage = D3D11_USAGE_DEFAULT;
+	texDesc.BindFlags = 0;
+	texDesc.CPUAccessFlags = 0;
+	texDesc.MiscFlags = 0;
+	HRESULT hr = _device->CreateTexture2D(&texDesc, nullptr, &_lastSubmittedTexture);
+	if (FAILED(hr)) return false;
+	_lastSubmittedWidth = width;
+	_lastSubmittedHeight = height;
+	_lastSubmittedFormat = format;
+	return true;
 }
 
 bool DX11::recover()
@@ -305,6 +341,12 @@ bool DX11::captureScreenWGC(ParsecDSO* ps)
 	ID3D11Texture2D* frame = _wgCapture.acquireFrame();
 	if (!frame)
 	{
+		if (_lastSubmittedTexture)
+		{
+			ParsecHostD3D11SubmitFrame(ps, 0, _device, _context, _lastSubmittedTexture);
+			_mutex.unlock();
+			return true;
+		}
 		_mutex.unlock();
 		return false;
 	}
@@ -321,7 +363,11 @@ bool DX11::captureScreenWGC(ParsecDSO* ps)
 		if (scaled) frameToSubmit = scaled;
 	}
 
+	D3D11_TEXTURE2D_DESC submitDesc;
+	frameToSubmit->GetDesc(&submitDesc);
 	ParsecHostD3D11SubmitFrame(ps, 0, _device, _context, frameToSubmit);
+	if (ensureLastSubmittedTexture(submitDesc.Width, submitDesc.Height, submitDesc.Format))
+		_context->CopyResource(_lastSubmittedTexture, frameToSubmit);
 
 	_mutex.unlock();
 	return true;
@@ -349,13 +395,17 @@ bool DX11::captureScreenDupl(ParsecDSO* ps)
 			lDesktopResource->Release();
 			_deskDupl->ReleaseFrame();
 		}
-
+		if (_lastSubmittedTexture)
+		{
+			ParsecHostD3D11SubmitFrame(ps, 0, _device, _context, _lastSubmittedTexture);
+			_mutex.unlock();
+			return true;
+		}
 		_mutex.unlock();
 		if (hr != DXGI_ERROR_WAIT_TIMEOUT)
 		{
 			clearAndRecover();
 		}
-
 		return false;
 	}
 
@@ -382,7 +432,11 @@ bool DX11::captureScreenDupl(ParsecDSO* ps)
 		}
 	}
 
+	D3D11_TEXTURE2D_DESC submitDesc;
+	frameToSubmit->GetDesc(&submitDesc);
 	ParsecHostD3D11SubmitFrame(ps, 0, _device, _context, frameToSubmit);
+	if (ensureLastSubmittedTexture(submitDesc.Width, submitDesc.Height, submitDesc.Format))
+		_context->CopyResource(_lastSubmittedTexture, frameToSubmit);
 
 	_deskDupl->ReleaseFrame();
 

--- a/SmashSoda/DX11.h
+++ b/SmashSoda/DX11.h
@@ -73,6 +73,9 @@ private:
 	void releaseScaledRenderTarget();
 	ID3D11Texture2D* scaleTexture(ID3D11Texture2D* source);
 
+	void releaseLastSubmittedTexture();
+	bool ensureLastSubmittedTexture(UINT width, UINT height, DXGI_FORMAT format);
+
 	HMONITOR getMonitorHandle();
 	bool captureScreenWGC(ParsecDSO* ps);
 	bool captureScreenDupl(ParsecDSO* ps);
@@ -111,6 +114,12 @@ private:
 	ID3D11Buffer* _lanczosParamsCB = nullptr;
 	bool _scalingInitialized = false;
 	bool _lanczosEnabled = true;
+
+	// Repeat last frame when capture misses (keeps frame pacing even)
+	ID3D11Texture2D* _lastSubmittedTexture = nullptr;
+	UINT _lastSubmittedWidth = 0;
+	UINT _lastSubmittedHeight = 0;
+	DXGI_FORMAT _lastSubmittedFormat = DXGI_FORMAT_UNKNOWN;
 
 	// Windows Graphics Capture
 	CaptureMethod _captureMethod = CaptureMethod::Auto;

--- a/SmashSoda/Hosting.cpp
+++ b/SmashSoda/Hosting.cpp
@@ -3,6 +3,12 @@
 #include "services/InputControlService.h"
 #include "services/GuestStateStore.h"
 #include <deque>
+#include <thread>
+#include <chrono>
+#ifdef _WIN32
+#include <timeapi.h>
+#pragma comment(lib, "winmm.lib")
+#endif
 
 using namespace std;
 
@@ -881,9 +887,14 @@ void Hosting::liveStreamMedia() {
 	_mediaMutex.lock();
 	_isMediaThreadRunning = true;
 
-	static uint32_t sleepTimeMs = 4;
-	_mediaClock.setDuration(sleepTimeMs);
-	_mediaClock.start();
+#ifdef _WIN32
+	// High-resolution timer (1ms) so Sleep() and pacing are more accurate; reduces stutter
+	timeBeginPeriod(1);
+#endif
+
+	// Frame pacing: target one video capture per (1000/fps) ms for even frame delivery
+	const uint32_t minFps = 10;
+	const uint32_t maxFps = 240;
 
 	const uint32_t SAFE_FREQUENCY = 48000;
 	const size_t SUBMIT_CHUNK_FRAMES = static_cast<size_t>(SAFE_FREQUENCY / 100); // 10ms
@@ -948,6 +959,20 @@ void Hosting::liveStreamMedia() {
 
 	while (_isRunning)
 	{
+		const bool usePacing = Config::cfg.video.framePacing;
+		double frameIntervalSec = 0.0;
+		std::chrono::steady_clock::time_point frameStart;
+
+		if (usePacing) {
+			uint32_t targetFps = Config::cfg.video.fps;
+			if (targetFps < minFps) targetFps = minFps;
+			if (targetFps > maxFps) targetFps = maxFps;
+			frameIntervalSec = 1.0 / static_cast<double>(targetFps);
+			_mediaClock.setDuration(static_cast<uint32_t>(1000.0 * frameIntervalSec));
+			frameStart = std::chrono::steady_clock::now();
+		} else {
+			_mediaClock.setDuration(4);
+		}
 		_mediaClock.reset();
 
 		_dx11.captureScreen(_parsec);
@@ -1030,15 +1055,24 @@ void Hosting::liveStreamMedia() {
 		if (submittedChunks == 0) {
 			submitSilence();
 		}
-		
 
-		sleepTimeMs = _mediaClock.getRemainingTime();
-		if (sleepTimeMs > 0)
-		{
-			Sleep(sleepTimeMs);
+		// Sleep until next frame time for even pacing
+		if (usePacing && frameIntervalSec > 0.0) {
+			auto elapsed = std::chrono::steady_clock::now() - frameStart;
+			double elapsedSec = std::chrono::duration<double>(elapsed).count();
+			double remainingSec = frameIntervalSec - elapsedSec;
+			if (remainingSec > 0.001)
+				std::this_thread::sleep_for(std::chrono::duration<double>(remainingSec));
+		} else {
+			uint32_t sleepTimeMs = _mediaClock.getRemainingTime();
+			if (sleepTimeMs > 0)
+				Sleep(sleepTimeMs);
 		}
 	}
 
+#ifdef _WIN32
+	timeEndPeriod(1);
+#endif
 	_isMediaThreadRunning = false;
 	_mediaMutex.unlock();
 	_mediaThread.detach();

--- a/SmashSoda/core/Config.cpp
+++ b/SmashSoda/core/Config.cpp
@@ -112,6 +112,7 @@ void Config::Load() {
 			cfg.video.windowH = setValue(cfg.video.windowH, j["Video"]["windowH"].get<int>());
 			cfg.video.resolutionIndex = setValue(cfg.video.resolutionIndex, j["Video"]["resolutionIndex"].get<unsigned int>());
 			cfg.video.lanczos = setValue(cfg.video.lanczos, j["Video"]["lanczos"].get<bool>());
+			cfg.video.framePacing = setValue(cfg.video.framePacing, j["Video"].value("framePacing", true));
 			cfg.video.captureMethod = setValue(cfg.video.captureMethod, j["Video"]["captureMethod"].get<unsigned int>());
 			cfg.video.fps = setValue(cfg.video.fps, j["Video"]["fps"].get<unsigned int>());
 			cfg.video.bandwidth = setValue(cfg.video.bandwidth, j["Video"]["bandwidth"].get<unsigned int>());
@@ -368,6 +369,7 @@ void Config::Save() {
 		{"windowH", cfg.video.windowH},
 		{"resolutionIndex", cfg.video.resolutionIndex},
 		{"lanczos", cfg.video.lanczos},
+		{"framePacing", cfg.video.framePacing},
 		{"captureMethod", cfg.video.captureMethod},
 		{"fps", cfg.video.fps},
 		{"bandwidth", cfg.video.bandwidth}

--- a/SmashSoda/core/Config.h
+++ b/SmashSoda/core/Config.h
@@ -61,6 +61,7 @@ public:
 		int windowH = 720;
 		unsigned int resolutionIndex = 0;
 		bool lanczos = true;
+		bool framePacing = true;
 		unsigned int captureMethod = 0;
 		unsigned int fps = 60;
 		unsigned int bandwidth = 20;

--- a/SmashSoda/widgets/VideoWidget.cpp
+++ b/SmashSoda/widgets/VideoWidget.cpp
@@ -119,6 +119,17 @@ bool VideoWidget::render(bool& showWindow)
     //TooltipWidget::render("High-quality scaling filter applied when output resolution differs from native.\nDisable to send frames at native resolution.");
 
     // =========================================================
+    // Frame rhythm
+    // =========================================================
+    static bool framePacingEnabled = Config::cfg.video.framePacing;
+    framePacingEnabled = Config::cfg.video.framePacing;
+
+    if (ImGui::Checkbox("Frame rhythm", &framePacingEnabled)) {
+        Config::cfg.video.framePacing = framePacingEnabled;
+        Config::cfg.Save();
+    }
+    TooltipWidget::render("Sends video frames at regular intervals (according to FPS). Reduces stutter for the client when enabled. Disable for legacy behavior (loop runs as fast as possible).");
+    // =========================================================
     // Bandwidth
     // =========================================================
     static int previousBandwidth;


### PR DESCRIPTION
- New Frame rhythm option in Video settings (on by default): when enabled, the media loop runs at a fixed interval (e.g. ~16.67 ms for 60 FPS) instead of as fast as possible.

- High-resolution timing: uses timeBeginPeriod(1) and std::chrono for sub-millisecond sleep so frame intervals are more accurate on Windows.

- Repeat last frame on capture miss: when a capture returns no new frame (e.g. WGC or Desktop Duplication timeout), the last submitted frame is sent again so the client still receives a frame every tick and pacing is kept even.